### PR TITLE
Addition of terms with URLs to documentation

### DIFF
--- a/snippets/language-logstash.cson
+++ b/snippets/language-logstash.cson
@@ -44,3 +44,9 @@
   'mutate (filter)':
     'prefix': 'mutate'
     'body': 'mutate {\n\t${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/plugins-filters-mutate.html}\n}'
+  'remove_field (array)':
+    'prefix': 'remove_field'
+    'body': 'remove_field => [ \"${1:field1}\", \"${2:field2}\" ]'
+  'add_field (hash)':
+    'prefix': 'add_field'
+    'body': 'add_field => { \"${1:new_field_name}\" \=\> \"%{source_field${2}}\" }'

--- a/snippets/language-logstash.cson
+++ b/snippets/language-logstash.cson
@@ -32,3 +32,6 @@
   'number':
     'prefix': 'num'
     'body': '${1:name} => $2'
+  'grok' :
+    'prefix': 'grok'
+    'body': 'grok {\n\t${1}match => { \"message\" => \"%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}\" }\n}'

--- a/snippets/language-logstash.cson
+++ b/snippets/language-logstash.cson
@@ -35,3 +35,9 @@
   'grok' :
     'prefix': 'grok'
     'body': 'grok {\n\t${1}match => { \"message\" => \"%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}\" }\n}'
+  'syslog_pri':
+    'prefix': 'syslog_pri'
+    'body': 'syslog_pri {\n\t${1}# Nothing else required if your PRI field is already called \"syslog_pri\", otherwise add the following:\n\t${1}# syslog_pri_field_name => "your_syslog_pri_field_name"\n}'
+  'syslog':
+    'prefix': 'syslog'
+    'body': 'syslog {\n\t${1}port => 5514\n} # Replace 5514 with your preferred port number to listen on' 

--- a/snippets/language-logstash.cson
+++ b/snippets/language-logstash.cson
@@ -1,43 +1,46 @@
 '.source.logstash':
   'input':
     'prefix': 'input'
-    'body': 'input {\n\t${1}\n}'
+    'body': 'input {\n\t${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/input-plugins.html}\n}'
   'filter':
     'prefix': 'filter'
-    'body': 'filter {\n\t${1}\n}'
+    'body': 'filter {\n\t${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/filter-plugins.html}\n}'
   'output':
     'prefix': 'output'
-    'body': 'output {\n\t${1}\n}'
-  'stdout':
+    'body': 'output {\n\t${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/output-plugins.html}\n}'
+  'stdout (output)':
     'prefix': 'stdout'
-    'body': 'stdout { $1 }'
+    'body': 'stdout { ${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/plugins-outputs-stdout.html} }'
   'codec':
     'prefix': 'codec'
-    'body': 'codec => ${1:name}$0'
+    'body': 'codec => ${1:name} ${2:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/codec-plugins.html}'
   'workers':
     'prefix': 'workers'
     'body': 'workers => ${1:number}$0'
-  'array':
+  'array (field)':
     'prefix': 'array'
     'body': '${1:name} => [ \"${2:value}\" ]'
-  'hash':
+  'hash (field)':
     'prefix': 'hash'
     'body': '${1:name} => { \"${2:key}\" => \"${3:value}\" }'
-  'string':
+  'string (field)':
     'prefix': 'string'
     'body': '${1:name} => \"${2:value}\"$3'
-  'boolean':
+  'boolean (field)':
     'prefix': 'boolean'
     'body': '${1:name} => $2true'
-  'number':
+  'number (field)':
     'prefix': 'num'
     'body': '${1:name} => $2'
-  'grok' :
+  'grok (filter)' :
     'prefix': 'grok'
-    'body': 'grok {\n\t${1}match => { \"message\" => \"%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}\" }\n}'
-  'syslog_pri':
+    'body': 'grok {\n\tmatch => { \"${1:message}\" => \"${2:grok\-pattern}\" }\n\t${3:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/plugins-filters-grok.html}\n}'
+  'syslog_pri (filter)':
     'prefix': 'syslog_pri'
-    'body': 'syslog_pri {\n\t${1}# Nothing else required if your PRI field is already called \"syslog_pri\", otherwise add the following:\n\t${1}# syslog_pri_field_name => "your_syslog_pri_field_name"\n}'
-  'syslog':
+    'body': 'syslog_pri {\n\t${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/plugins-filters-syslog_pri.html}\n}'
+  'syslog (input)':
     'prefix': 'syslog'
-    'body': 'syslog {\n\t${1}# use port => 000 to set your preferred port number here, if not the default\n}'
+    'body': 'syslog {\n\t${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/plugins-inputs-syslog.html}\n}'
+  'mutate (filter)':
+    'prefix': 'mutate'
+    'body': 'mutate {\n\t${1:#https:\/\/www.elastic.co\/guide\/en\/logstash\/current\/plugins-filters-mutate.html}\n}'

--- a/snippets/language-logstash.cson
+++ b/snippets/language-logstash.cson
@@ -40,4 +40,4 @@
     'body': 'syslog_pri {\n\t${1}# Nothing else required if your PRI field is already called \"syslog_pri\", otherwise add the following:\n\t${1}# syslog_pri_field_name => "your_syslog_pri_field_name"\n}'
   'syslog':
     'prefix': 'syslog'
-    'body': 'syslog {\n\t${1}port => 5514\n} # Replace 5514 with your preferred port number to listen on' 
+    'body': 'syslog {\n\t${1}# use port => 000 to set your preferred port number here, if not the default\n}'


### PR DESCRIPTION
1. Added the following terms:
  - grok filter
  - syslog input
  - syslog_pri filter
  - mutate filter
  - add_field
  - remove_field

2. No longer using the hard-coded 5514 ( from #11 )

3. for each, added "#" (comment) folloed by the relevant docmentation URL to make it easy to reference